### PR TITLE
Support for creating new tox environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This configuration section contains the relevant fields for creating new tox env
 
 | Fields | Description | Sample value |
 | - | - | - |
-| filePath | File path to the template file. The content of this file is copied when creating a new tox env. Support for token replacement. The following tokens are supported: `TOX_ENV_NAME` | "/usr/template.tox.new"
+| templateFilePath | File path to the template file. The content of this file is copied when creating a new tox env. Support for token replacement. The following tokens are supported: `TOX_ENV_NAME` | "/usr/template.tox.new"
 
 #### Sample template file
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,26 @@ Then install the resulting `.vsix` file using the command palette and selecting
 
 ## Extension Commands
 
-* `python-tox.select`: Show a menu allowing to pick a tox environment.
-* `python-tox.selectMultiple`: Show a menu allowing to pick multiple tox environments.
+- `python-tox.select`: Show a menu allowing to pick a tox environment.
+- `python-tox.selectMultiple`: Show a menu allowing to pick multiple tox environments.
+- `python-tox.createEnv`: A guided process to add a new tox environment to an existing tox.ini.
+
+## Configuration
+
+### python-tox.environment.template.new
+
+This configuration section contains the relevant fields for creating new tox environments.
+
+| Fields | Description | Sample value |
+| - | - | - |
+| filePath | File path to the template file. The content of this file is copied when creating a new tox env. Support for token replacement. The following tokens are supported: `TOX_ENV_NAME` | "/usr/template.tox.new"
+
+#### Sample template file
+
+```ini
+[testenv:[${TOX_ENV_NAME}]
+commands = {envpython} -c "print('one']"
+```
 
 ## Release Notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,12 @@
       "name": "python-tox",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
       "devDependencies": {
         "@types/glob": "^7.2.0",
+        "@types/lodash": "^4.14.181",
         "@types/mocha": "^9.1.0",
         "@types/node": "^17.0.23",
         "@types/vscode": "^1.66.0",
@@ -19,11 +23,12 @@
         "eslint": "^8.12.0",
         "glob": "^7.2.0",
         "mocha": "^9.2.2",
+        "ts-mockito": "^2.6.1",
         "typescript": "^4.6.3",
         "vsce": "^2.7.0"
       },
       "engines": {
-        "vscode": "^1.57.0"
+        "vscode": "^1.66.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -124,6 +129,12 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.181",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.181.tgz",
+      "integrity": "sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag==",
       "dev": true
     },
     "node_modules/@types/minimatch": {
@@ -2055,6 +2066,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3125,6 +3141,15 @@
         "node": "*"
       }
     },
+    "node_modules/ts-mockito": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/ts-mockito/-/ts-mockito-2.6.1.tgz",
+      "integrity": "sha512-qU9m/oEBQrKq5hwfbJ7MgmVN5Gu6lFnIGWvpxSjrqq6YYEVv+RwVFWySbZMBgazsWqv6ctAyVBpo9TmAxnOEKw==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.5"
+      }
+    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -3640,6 +3665,12 @@
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.181",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.181.tgz",
+      "integrity": "sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag==",
       "dev": true
     },
     "@types/minimatch": {
@@ -5050,6 +5081,11 @@
         "p-locate": "^5.0.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -5835,6 +5871,15 @@
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
       "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
       "dev": true
+    },
+    "ts-mockito": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/ts-mockito/-/ts-mockito-2.6.1.tgz",
+      "integrity": "sha512-qU9m/oEBQrKq5hwfbJ7MgmVN5Gu6lFnIGWvpxSjrqq6YYEVv+RwVFWySbZMBgazsWqv6ctAyVBpo9TmAxnOEKw==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.5"
+      }
     },
     "tslib": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "activationEvents": [
     "onCommand:python-tox.select",
     "onCommand:python-tox.selectMultiple",
-    "onCommand:python-tox.openDocs"
+    "onCommand:python-tox.openDocs",
+    "onCommand:python-tox.createEnv"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -56,8 +57,25 @@
       {
         "command": "python-tox.openDocs",
         "title": "Open tox documentation in default browser"
+      },
+      {
+        "command": "python-tox.createEnv",
+        "title": "Create new tox environment"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "python-tox",
+      "properties": {
+        "python-tox.environment.template.new": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "default": null,
+          "description": "Path to template file (within workspace)"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
@@ -77,10 +95,15 @@
     "@typescript-eslint/eslint-plugin": "^5.18.0",
     "@typescript-eslint/parser": "^5.18.0",
     "@vscode/test-electron": "^2.1.3",
+    "@types/lodash": "^4.14.181",
     "eslint": "^8.12.0",
     "glob": "^7.2.0",
     "mocha": "^9.2.2",
+    "ts-mockito": "^2.6.1",
     "typescript": "^4.6.3",
     "vsce": "^2.7.0"
+  },
+  "dependencies": {
+    "lodash": "^4.17.21"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,8 +3,10 @@ import * as child_process from 'child_process';
 import * as util from 'util';
 import * as path from 'path';
 import * as os from 'os';
+import { ToxEnvironmentService } from './service/toxEnvironmentService';
 
 const exec = util.promisify(child_process.exec);
+const ExtensionName = "python-tox";
 
 function findProjectDir() {
 	const docUri = vscode.window.activeTextEditor?.document.uri;
@@ -89,12 +91,34 @@ async function openDocumentationCommand() {
 	vscode.env.openExternal(vscode.Uri.parse("https://tox.wiki"));
 }
 
+/**
+ * Handler called when extenion gets activated
+ * @param context 
+ */
 export function activate(context: vscode.ExtensionContext) {
+
+	// initialize command handlers)
+	initializeServices();
+
 	context.subscriptions.push(
 		vscode.commands.registerCommand('python-tox.select', selectCommand),
 		vscode.commands.registerCommand('python-tox.selectMultiple', selectMultipleCommand),
-		vscode.commands.registerCommand('python-tox.openDocs', openDocumentationCommand)
+		vscode.commands.registerCommand('python-tox.openDocs', openDocumentationCommand),
+
+		// add a new tox environment config to the tox.ini file
+		vscode.commands.registerCommand(
+			ToxEnvironmentService.COMMAND_NEW_ENVIRONMENT, 
+			() => environmentService.createNewEnvironment(path.join(findProjectDir(),"tox.ini")))
 	);
+}
+
+let environmentService : ToxEnvironmentService;
+
+/**
+ * Initialize extension services
+ */
+function initializeServices() {
+	environmentService = new ToxEnvironmentService(ExtensionName);
 }
 
 export function deactivate() {}
@@ -104,3 +128,5 @@ export const _private = {
 	getToxEnvs,
 	runTox,
 };
+
+

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,10 @@ import * as os from 'os';
 import { ToxEnvironmentService } from './service/toxEnvironmentService';
 
 const exec = util.promisify(child_process.exec);
-const ExtensionName = "python-tox";
+const extensionName = "python-tox";
+const toxIni = "tox.ini";
+
+let environmentService : ToxEnvironmentService;
 
 function findProjectDir() {
 	const docUri = vscode.window.activeTextEditor?.document.uri;
@@ -107,18 +110,16 @@ export function activate(context: vscode.ExtensionContext) {
 
 		// add a new tox environment config to the tox.ini file
 		vscode.commands.registerCommand(
-			ToxEnvironmentService.COMMAND_NEW_ENVIRONMENT, 
-			() => environmentService.createNewEnvironment(path.join(findProjectDir(),"tox.ini")))
+			ToxEnvironmentService.commandNewEnvironment, 
+			() => environmentService.createNewEnvironment(path.join(findProjectDir(), toxIni)))
 	);
 }
-
-let environmentService : ToxEnvironmentService;
 
 /**
  * Initialize extension services
  */
 function initializeServices() {
-	environmentService = new ToxEnvironmentService(ExtensionName);
+	environmentService = new ToxEnvironmentService(extensionName);
 }
 
 export function deactivate() {}

--- a/src/model/toxConfiguration.ts
+++ b/src/model/toxConfiguration.ts
@@ -5,5 +5,5 @@ export interface ConfigNewEnvironment {
     /**
      * Template file path
      */
-    filePath: string;
+    templateFilePath: string;
 }

--- a/src/model/toxConfiguration.ts
+++ b/src/model/toxConfiguration.ts
@@ -1,0 +1,9 @@
+/**
+ * Model representing the config section "new environment"
+ */
+export interface ConfigNewEnvironment {
+    /**
+     * Template file path
+     */
+    filePath: string;
+}

--- a/src/model/toxEnvironment.ts
+++ b/src/model/toxEnvironment.ts
@@ -1,0 +1,15 @@
+import { Uri } from 'vscode';
+
+/**
+ * Definition of a tox environment
+ */
+export interface ToxEnvironment {
+    /**
+     * Name of the tox environment
+     */
+    name: string,
+    /**
+     * Uri of the tox.ini that contains the environment definition
+     */
+    doc: Uri
+};

--- a/src/service/toxEnvironmentService.ts
+++ b/src/service/toxEnvironmentService.ts
@@ -1,0 +1,107 @@
+import * as vscode from 'vscode';
+import { ConfigNewEnvironment } from '../model/toxConfiguration';
+import * as fs from 'fs';
+import * as _ from "lodash";
+
+/**
+ * The ToxEnvironmentService enables clients to 
+ * work with tox environments
+ */
+export class ToxEnvironmentService {
+
+    /**
+     * VSCode command id to create a new tox environment
+     */
+    public static COMMAND_NEW_ENVIRONMENT = "python-tox.createEnv";
+
+    private readonly _extensionName: string;
+    private readonly _tokenDelimiter: RegExp;
+
+    /**
+     * Constructor
+     * @param extensionName Extensions name
+     * @param tokenDelimiter Token delimitor for updating config templates
+     */
+    public constructor(extensionName: string, tokenDelimiter: RegExp = /\${([\s\S]+?)}/g) {
+        if (!extensionName) {
+            throw new TypeError("ExtensionName is invalid")
+        }
+        if (!tokenDelimiter) {
+            throw new TypeError("TokenDelimiter is invalid");
+        }
+
+        this._extensionName = extensionName;
+        this._tokenDelimiter = tokenDelimiter;
+    }
+
+    /**
+     * Create a new tox environment
+     * @param toxIniPath Add tox environment to this tox config file
+     * @param templateConfigSection config section id that contains the env templates
+     * @returns 
+     */
+    public async createNewEnvironment(toxIniPath: string, templateConfigSection: string = "environment.template.new") {   
+        const inputBoxTitle = `${this._extensionName}: Create Tox Environment`
+
+        // get the tox.ini path
+        const toxInitPathConfirmed = await vscode.window.showInputBox({ 
+            title: inputBoxTitle, 
+            prompt: "Enter tox.ini path", 
+            value: toxIniPath, validateInput: (input) => (!input || !fs.existsSync(input)) ? "File does not exist" :""
+        });
+        if (!toxInitPathConfirmed) {
+            // user cancelled operation
+            return;
+        }
+        
+        // get the name of the new tox environment
+        const newEnvName = await vscode.window.showInputBox({ 
+            title: inputBoxTitle, 
+            prompt: "Enter new tox environment name", 
+            value: "my-new-tox-env",
+            validateInput: (input) => (input == undefined || input.length == 0) ? "Invalid environment name" : "" 
+        });
+        if (!newEnvName) {
+            // user cancelled operation
+            return;
+        }
+
+        // retrieve the configured template for a new tox env
+        const templateConfig = vscode.workspace
+                                    .getConfiguration(this._extensionName)
+                                    ?.get<ConfigNewEnvironment>(templateConfigSection);
+
+        // create the new env string
+        let toxEnvironmentConfig = `[${newEnvName}]`;									
+        if (templateConfig && templateConfig.filePath) {
+            // read the content & do string interpolation
+            toxEnvironmentConfig = this.prepareEnvironmentConfig(templateConfig.filePath, newEnvName);
+        }
+
+        // add new env to tox.ini
+        var { success, doc } = await this.addToxEnvironment(toxInitPathConfirmed, toxEnvironmentConfig);
+        if (success) {
+            const editor = await vscode.window.showTextDocument(doc, { preview: false });
+        }
+    }
+
+    private async addToxEnvironment(toxIniPath: string, template: string) {
+        const doc = await vscode.workspace.openTextDocument(vscode.Uri.file(toxIniPath));
+        const edit = new vscode.WorkspaceEdit();
+        edit.insert(doc.uri, new vscode.Position(doc.lineCount + 1, 0), template);
+        let success = await vscode.workspace.applyEdit(edit);
+
+        return { success, doc };
+    }
+
+    private prepareEnvironmentConfig(templatePath: fs.PathOrFileDescriptor, toxEnvName: string) {
+        const variableMap = {
+            TOX_ENV_NAME: toxEnvName
+        };
+        _.templateSettings.interpolate = this._tokenDelimiter;
+        
+        const templateContent = fs.readFileSync(templatePath);
+        const compiled = _.template(templateContent.toString());
+        return compiled(variableMap);
+    }
+}

--- a/src/service/toxEnvironmentService.ts
+++ b/src/service/toxEnvironmentService.ts
@@ -68,7 +68,7 @@ export class ToxEnvironmentService {
         }
 
         // retrieve the configured template for a new tox env
-        const templateConfig = vscode.workspace
+        const templateConfig: ConfigNewEnvironment | undefined = vscode.workspace
                                     .getConfiguration(this._extensionName)
                                     ?.get<ConfigNewEnvironment>(templateConfigSection);
 
@@ -76,7 +76,7 @@ export class ToxEnvironmentService {
         let toxEnvironmentConfig = `[${newEnvName}]`;									
         if (templateConfig && templateConfig.templateFilePath) {
             // read the content & do string interpolation
-            toxEnvironmentConfig = this.prepareEnvironmentConfig(templateConfig.templateFilePath, newEnvName);
+            toxEnvironmentConfig = await this.prepareEnvironmentConfig(templateConfig.templateFilePath, newEnvName);
         }
 
         // add new env to tox.ini
@@ -100,7 +100,7 @@ export class ToxEnvironmentService {
         return (await vscode.workspace.applyEdit(edit)) ? doc : undefined;
     }
 
-    private prepareEnvironmentConfig(templatePath: string, toxEnvName: string): string {
+    private async prepareEnvironmentConfig(templatePath: string, toxEnvName: string): Promise<string> {
         /* eslint-disable @typescript-eslint/naming-convention */
         const variableMap = {
             TOX_ENV_NAME: toxEnvName
@@ -109,8 +109,8 @@ export class ToxEnvironmentService {
         
         _.templateSettings.interpolate = this._tokenDelimiter;
         
-        const templateContent = vscode.workspace.fs.readFile(vscode.Uri.file(templatePath));
+        const templateContent = await vscode.workspace.fs.readFile(vscode.Uri.file(templatePath));
         const compiled = _.template(templateContent.toString());
-        return compiled(variableMap);
+        return `\n${compiled(variableMap)}`;
     }
 }

--- a/src/test/examples/createenv/settings.json
+++ b/src/test/examples/createenv/settings.json
@@ -1,0 +1,5 @@
+{
+    "python-tox.environment.template.new": {
+        "filePath": "template.createenv.ini"
+    }
+}

--- a/src/test/examples/createenv/template.createenv.ini
+++ b/src/test/examples/createenv/template.createenv.ini
@@ -1,0 +1,2 @@
+[testenv:[${TOX_ENV_NAME}]
+commands = {envpython} -c "print('one']"

--- a/src/test/examples/createenv/tox.ini
+++ b/src/test/examples/createenv/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+skipsdist = True
+envlist = one,two
+
+[testenv:one]
+commands = {envpython} -c "print('one')"
+
+[testenv:two]
+commands = {envpython} -c "print('two')"
+
+[testenv:three]
+commands = {envpython} -c "print('three')"


### PR DESCRIPTION
Create tox envs based on configurable env templates.
  - Added new VSCode config section (`python-tox.environment.template.new`) to specify env templates
  - Env templates support token replacements (using lodash)
  - Added automated tests (incl mocks where user input is required)
  - Updated doc (README.md)