### PR TITLE
Added references to recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846
+	// for the documentation about the extensions.json format
+	"recommendations": [
+		"dbaeumer.vscode-eslint",
+		"davidwang.ini-for-vscode"
+	]
+}

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
          align="right">
 </a>
 
-
 [![VS Marketplace Version](https://vsmarketplacebadge.apphb.com/version/the-compiler.python-tox.svg)](https://marketplace.visualstudio.com/items?itemName=the-compiler.python-tox)
 [![VS Marketplace Installs](https://vsmarketplacebadge.apphb.com/installs/the-compiler.python-tox.svg)](https://marketplace.visualstudio.com/items?itemName=the-compiler.python-tox)
 [![VS Marketplace Ratings](https://vsmarketplacebadge.apphb.com/rating/the-compiler.python-tox.svg)](https://marketplace.visualstudio.com/items?itemName=the-compiler.python-tox)
@@ -79,8 +78,13 @@ Then install the resulting `.vsix` file using the command palette and selecting
 
 ## Extension Commands
 
-* `python-tox.select`: Show a menu allowing to pick a tox environment.
-* `python-tox.selectMultiple`: Show a menu allowing to pick multiple tox environments.
+- `python-tox.select`: Show a menu allowing to pick a tox environment.
+- `python-tox.selectMultiple`: Show a menu allowing to pick multiple tox environments.
+
+## Recommended Extensions
+
+- [Ini for VSCode](https://marketplace.visualstudio.com/items?itemName=DavidWang.ini-for-vscode) for simpler navigation of large tox.ini files
+- [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) for EsLint integration into VSCode
 
 ## Release Notes
 


### PR DESCRIPTION
While developing we found this nice way to reference other extensions, that might be helpful.

These extensions will show up in the Recommended extension list in the "Extensions" section of VS Code upon installing this one.

Also, minor Markdown fixes.