### PR TITLE
Provide a preview feature for tox.ini files

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+	// See http://go.microsoft.com/fwlink/?LinkId=827846
+	// for the documentation about the extensions.json format
+	"recommendations": [
+		"dbaeumer.vscode-eslint"
+	]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,34 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Run Extension",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/**/*.js"
+			],
+			"preLaunchTask": "${defaultBuildTask}"
+		},
+		{
+			"name": "Extension Tests",
+			"type": "extensionHost",
+			"request": "launch",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/test/**/*.js"
+			],
+			"preLaunchTask": "${defaultBuildTask}"
+		}
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+// Place your settings in this file to overwrite default and user settings.
+{
+    "files.exclude": {
+        "out": false // set this to true to hide the "out" folder with the compiled JS files
+    },
+    "search.exclude": {
+        "out": true // set this to false to include "out" folder in search results
+    },
+    // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
+    "typescript.tsc.autoDetect": "off"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,20 @@
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "watch",
+			"problemMatcher": "$tsc-watch",
+			"isBackground": true,
+			"presentation": {
+				"reveal": "never"
+			},
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "activationEvents": [
     "onCommand:python-tox.select",
     "onCommand:python-tox.selectMultiple",
-    "onCommand:python-tox.openDocs"
+    "onCommand:python-tox.openDocs",
+    "onLanguage:ini"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/src/environment_variables_service.ts
+++ b/src/environment_variables_service.ts
@@ -2,6 +2,8 @@ import * as vscode from 'vscode';
 
 export class EnvironmentVariablesService implements vscode.HoverProvider {
 
+  public environmentVariables = new Map<string, string>();
+
   public provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Hover> {
     this.updateEnvironmentVariables(document);
     return {
@@ -9,21 +11,30 @@ export class EnvironmentVariablesService implements vscode.HoverProvider {
     };
   }
 
-  public updateEnvironmentVariables(document: vscode.TextDocument): Map<string, string> {
+  /**
+   * 
+   * @param document The document to search for environments variables.
+   * @returns true if environment variables have been found; false otherwise.
+   */
+  public updateEnvironmentVariables(document: vscode.TextDocument): boolean {
     // Regular expression and code based on https://regex101.com/r/Yn6dAs/1.
     const regex = /(^(?<key>passenv)(?: |)*=(?: |)*(?<value>[^#;\\\r\n]*(?:\\.[^#;\\\r\n]*)*))/gm;
-
-    let environmentVariables = new Map<string, string>();
 
     const documentText: string = document.getText();
 
     let match = regex.exec(documentText);
 
-    if (match && match.groups) {
-      environmentVariables.set(match.groups.key, match.groups.value);
-    }
+    this.environmentVariables.clear();
 
-    return environmentVariables;
+    if (match && match.groups) {
+      this.environmentVariables.set(match.groups.key, match.groups.value);
+
+      // Indicate environment variables have been found.
+      return true;
+    } else {
+      // Indicate NO environment variables have been found.
+      return false;
+    }
   }
 
   private generateHoverMessage(document: vscode.TextDocument, position: vscode.Position): vscode.MarkdownString[] {

--- a/src/environment_variables_service.ts
+++ b/src/environment_variables_service.ts
@@ -5,11 +5,29 @@ export class EnvironmentVariablesService {
   public static createHoverProvider(): vscode.HoverProvider {
     return {
       provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Hover> {
+        EnvironmentVariablesService.collectEnvironmentVariables(document);
         return {
           contents: [`Hover Content in '${document.fileName}' at line ${position.line} char ${position.character}`]
         };
       }
     };
+  }
+
+  public static collectEnvironmentVariables(document: vscode.TextDocument): Map<string, string> {
+    // Regular expression and code based on https://regex101.com/r/Yn6dAs/1.
+    const regex = /(^(?<key>passenv)(?: |)*=(?: |)*(?<value>[^#;\\\r\n]*(?:\\.[^#;\\\r\n]*)*))/gm;
+
+    let environmentVariables = new Map<string, string>();
+
+    const documentText: string = document.getText();
+
+    let match = regex.exec(documentText);
+
+    if (match && match.groups) {
+        environmentVariables.set(match.groups.key, match.groups.value);
+    }
+
+    return environmentVariables;
   }
 
 }

--- a/src/environment_variables_service.ts
+++ b/src/environment_variables_service.ts
@@ -101,7 +101,7 @@ export class EnvironmentVariablesService implements vscode.HoverProvider {
 
         switch (envVarKey) {
           case "passenv":
-            
+
             this.resolvePassEnvAssignment(sectionName, envVarAssignment);
 
             break;
@@ -109,7 +109,7 @@ export class EnvironmentVariablesService implements vscode.HoverProvider {
           case "setenv":
 
             this.resolveSetEnvAssignment(sectionName, document, envVarAssignment);
-  
+
             break;
         }
 
@@ -135,11 +135,11 @@ export class EnvironmentVariablesService implements vscode.HoverProvider {
       const trimmedLine = line.trim();
 
       if (trimmedLine) {  // ensure line is not empty after trimming
-      
+
         const envVarValue = process.env[trimmedLine] ?? "n/a";
 
-        this.setToxEnvironmentVariableValue(sectionName, trimmedLine, envVarValue);    
-      
+        this.setToxEnvironmentVariableValue(sectionName, trimmedLine, envVarValue);
+
       }
     }
   }
@@ -163,7 +163,7 @@ export class EnvironmentVariablesService implements vscode.HoverProvider {
           this.resolveSetEnvDirectValue(sectionName, trimmedLine);
 
         }
-        
+
       }
     }
   }
@@ -247,15 +247,32 @@ export class EnvironmentVariablesService implements vscode.HoverProvider {
     const sectionName = EnvironmentVariablesService.determineSection(document, position);
     const value = this.getToxEnvironmentVariableValue(sectionName, wordAtPosition);
 
-    if (value) {
+    let returnValue: { sectionName: string, varName: string, varValue: string } | null;
 
-      return { sectionName: sectionName, varName: wordAtPosition, varValue: value };
+    if (value) {  // Environment variable name found in current section.
 
-    } else {
+      returnValue = { sectionName: sectionName, varName: wordAtPosition, varValue: value };
 
-      return null;
+    } else {    // Environment variable name NOT found in current section.
+
+      // Look up environment variable name in inherited section testenv.
+      const valueFromTestenv = this.getToxEnvironmentVariableValue("testenv", wordAtPosition);
+
+      if (valueFromTestenv) {  // Environment variable name found in current section.
+
+        returnValue = { sectionName: "testenv", varName: wordAtPosition, varValue: valueFromTestenv };
+
+      } else {
+        // Environment variable name neither found in current section 
+        // nor in inherited section testenv. 
+
+        returnValue = null;
+
+      }
 
     }
+
+    return returnValue;
   }
 
   public getToxEnvironmentVariableValue(sectionName: string, varName: string): string | null {

--- a/src/environment_variables_service.ts
+++ b/src/environment_variables_service.ts
@@ -40,7 +40,7 @@ export class EnvironmentVariablesService implements vscode.HoverProvider {
     if (match && match.groups) {
 
       const envVarName = match.groups.value;
-      const envVarValue = process.env[envVarName] ?? "";
+      const envVarValue = process.env[envVarName] ?? "environment variable not found";
 
       this.environmentVariables.set(envVarName, envVarValue);
 
@@ -51,7 +51,7 @@ export class EnvironmentVariablesService implements vscode.HoverProvider {
 
       // Indicate NO environment variables have been found.
       return false;
-      
+
     }
   }
 
@@ -62,6 +62,8 @@ export class EnvironmentVariablesService implements vscode.HoverProvider {
     if (keyValuePair) {
 
       const hoverMessage = new vscode.MarkdownString(`${keyValuePair.key}: '${keyValuePair.value}'`);
+
+      console.log(`hover message: ${hoverMessage.value}`);
 
       return [hoverMessage];
 

--- a/src/environment_variables_service.ts
+++ b/src/environment_variables_service.ts
@@ -1,19 +1,14 @@
 import * as vscode from 'vscode';
 
-export class EnvironmentVariablesService {
-
-  public static createHoverProvider(): vscode.HoverProvider {
+export class EnvironmentVariablesService implements vscode.HoverProvider {
+  public provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Hover> {
+    this.collectEnvironmentVariables(document);
     return {
-      provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Hover> {
-        EnvironmentVariablesService.collectEnvironmentVariables(document);
-        return {
-          contents: [`Hover Content in '${document.fileName}' at line ${position.line} char ${position.character}`]
-        };
-      }
+      contents: this.generateHoverMessage(document, position)
     };
   }
 
-  public static collectEnvironmentVariables(document: vscode.TextDocument): Map<string, string> {
+  public collectEnvironmentVariables(document: vscode.TextDocument): Map<string, string> {
     // Regular expression and code based on https://regex101.com/r/Yn6dAs/1.
     const regex = /(^(?<key>passenv)(?: |)*=(?: |)*(?<value>[^#;\\\r\n]*(?:\\.[^#;\\\r\n]*)*))/gm;
 
@@ -24,10 +19,17 @@ export class EnvironmentVariablesService {
     let match = regex.exec(documentText);
 
     if (match && match.groups) {
-        environmentVariables.set(match.groups.key, match.groups.value);
+      environmentVariables.set(match.groups.key, match.groups.value);
     }
 
     return environmentVariables;
   }
 
+  private generateHoverMessage(document: vscode.TextDocument, position: vscode.Position): vscode.MarkdownString[] {
+    const hoverMessage = new vscode.MarkdownString(`Hover Content in '${document.fileName}' at line ${position.line} char ${position.character}`);
+
+    return [hoverMessage];
+  }
+
 }
+

--- a/src/environment_variables_service.ts
+++ b/src/environment_variables_service.ts
@@ -244,7 +244,7 @@ export class EnvironmentVariablesService implements vscode.HoverProvider {
 
     console.log(`Word '${wordAtPosition}' at position (${position.line}, ${position.character}) with range from (${range?.start.line}, ${range?.start.character}) to (${range?.end.line}, ${range?.end.character})`);
 
-    const sectionName = this.determineSection(document, position);
+    const sectionName = EnvironmentVariablesService.determineSection(document, position);
     const value = this.getToxEnvironmentVariableValue(sectionName, wordAtPosition);
 
     if (value) {
@@ -284,7 +284,7 @@ export class EnvironmentVariablesService implements vscode.HoverProvider {
 
   }
 
-  public determineSection(document: vscode.TextDocument, position: vscode.Position): string {
+  public static determineSection(document: vscode.TextDocument, position: vscode.Position): string {
 
     const positionStart = new vscode.Position(0, 0);
     const positionEnd = new vscode.Position(position.line + 1, 0);

--- a/src/environment_variables_service.ts
+++ b/src/environment_variables_service.ts
@@ -190,11 +190,11 @@ export class EnvironmentVariablesService implements vscode.HoverProvider {
 
   public generateHoverMessage(document: vscode.TextDocument, position: vscode.Position): vscode.MarkdownString[] | null {
 
-    const keyValuePair = this.getEnvVarDataForPosition(document, position);
+    const envVarData = this.getEnvVarDataForPosition(document, position);
 
-    if (keyValuePair) {
+    if (envVarData) {
 
-      const hoverMessage = new vscode.MarkdownString(`${keyValuePair.name}: '${keyValuePair.value}'`);
+      const hoverMessage = new vscode.MarkdownString(`[${envVarData.sectionName}] ${envVarData.varName}: '${envVarData.varValue}'`);
 
       console.log(`hover message: ${hoverMessage.value}`);
 
@@ -218,7 +218,7 @@ export class EnvironmentVariablesService implements vscode.HoverProvider {
 
     if (value) {
 
-      return { name: wordAtPosition, value: value };
+      return { sectionName: sectionName, varName: wordAtPosition, varValue: value };
 
     } else {
 

--- a/src/environment_variables_service.ts
+++ b/src/environment_variables_service.ts
@@ -1,0 +1,15 @@
+import * as vscode from 'vscode';
+
+export class EnvironmentVariablesService {
+
+  public static createHoverProvider(): vscode.HoverProvider {
+    return {
+      provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Hover> {
+        return {
+          contents: [`Hover Content in '${document.fileName}' at line ${position.line} char ${position.character}`]
+        };
+      }
+    };
+  }
+
+}

--- a/src/environment_variables_service.ts
+++ b/src/environment_variables_service.ts
@@ -73,15 +73,15 @@ export class EnvironmentVariablesService implements vscode.HoverProvider {
           const fileReferencePrefix = 'file|';
 
           if (envVarValue.startsWith(fileReferencePrefix)) {
-      
+
             this.updateSetEnvFileReference(document, envVarValue.substring(fileReferencePrefix.length));
-      
+
           } else {  // direct value assignment
-      
+
             this.updateSetEnvDirectValue(envVarValue);
-      
+
           }
-      
+
         }
 
         // Indicate environment variables have been found.
@@ -186,6 +186,37 @@ export class EnvironmentVariablesService implements vscode.HoverProvider {
       return null;
 
     }
+  }
+
+  public determineSection(document: vscode.TextDocument, position: vscode.Position): string {
+
+    const positionStart = new vscode.Position(0,0);
+    const positionEnd = new vscode.Position(position.line + 1, 0);
+    const range = new vscode.Range(positionStart, positionEnd);
+    const documentText: string = document.getText(range);
+
+    const regex = /(?:^(?: +|)\[(?<section>[^#;\r\n]+)\])/mg;
+
+    let lastSectionName = "";
+
+    let match: RegExpExecArray | null;
+
+    while ((match = regex.exec(documentText)) !== null) {
+
+      // This is necessary to avoid infinite loops with zero-width matches
+      if (match.index === regex.lastIndex) {
+        regex.lastIndex++;
+      }
+
+      if (match && match.groups) {
+
+        lastSectionName = match.groups.section;
+
+      }
+    }
+
+    return lastSectionName;
+
   }
 
 }

--- a/src/environment_variables_service.ts
+++ b/src/environment_variables_service.ts
@@ -1,14 +1,15 @@
 import * as vscode from 'vscode';
 
 export class EnvironmentVariablesService implements vscode.HoverProvider {
+
   public provideHover(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Hover> {
-    this.collectEnvironmentVariables(document);
+    this.updateEnvironmentVariables(document);
     return {
       contents: this.generateHoverMessage(document, position)
     };
   }
 
-  public collectEnvironmentVariables(document: vscode.TextDocument): Map<string, string> {
+  public updateEnvironmentVariables(document: vscode.TextDocument): Map<string, string> {
     // Regular expression and code based on https://regex101.com/r/Yn6dAs/1.
     const regex = /(^(?<key>passenv)(?: |)*=(?: |)*(?<value>[^#;\\\r\n]*(?:\\.[^#;\\\r\n]*)*))/gm;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,11 +91,13 @@ async function openDocumentationCommand() {
 }
 
 export function activate(context: vscode.ExtensionContext) {
+	const environmentVariablesService = new EnvironmentVariablesService();
+
 	context.subscriptions.push(
 		vscode.commands.registerCommand('python-tox.select', selectCommand),
 		vscode.commands.registerCommand('python-tox.selectMultiple', selectMultipleCommand),
 		vscode.commands.registerCommand('python-tox.openDocs', openDocumentationCommand),
-		vscode.languages.registerHoverProvider(['ini'], EnvironmentVariablesService.createHoverProvider())
+		vscode.languages.registerHoverProvider(['ini'], environmentVariablesService)
 	);
 
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import * as child_process from 'child_process';
 import * as util from 'util';
 import * as path from 'path';
 import * as os from 'os';
+import { EnvironmentVariablesService } from './environment_variables_service';
 
 const exec = util.promisify(child_process.exec);
 
@@ -26,7 +27,7 @@ function findProjectDir() {
 }
 
 async function getToxEnvs(projDir: string) {
-	const { stdout } = await exec('tox -a', {cwd: projDir});
+	const { stdout } = await exec('tox -a', { cwd: projDir });
 	return stdout.trim().split(os.EOL);
 }
 
@@ -40,7 +41,7 @@ async function safeGetToxEnvs(projDir: string) {
 }
 
 function runTox(envs: string[], projDir: string) {
-	const term = vscode.window.createTerminal({"cwd": projDir, "name": "tox"});
+	const term = vscode.window.createTerminal({ "cwd": projDir, "name": "tox" });
 	const envArg = envs.join(",");
 	term.show(true);  // preserve focus
 
@@ -65,7 +66,7 @@ async function selectCommand() {
 	if (!envs) {
 		return;
 	}
-	const selected = await vscode.window.showQuickPick(envs, {placeHolder: "tox environment"});
+	const selected = await vscode.window.showQuickPick(envs, { placeHolder: "tox environment" });
 	if (!selected) {
 		return;
 	}
@@ -78,7 +79,7 @@ async function selectMultipleCommand() {
 	if (!envs) {
 		return;
 	}
-	const selected = await vscode.window.showQuickPick(envs, {placeHolder: "tox environments", canPickMany: true});
+	const selected = await vscode.window.showQuickPick(envs, { placeHolder: "tox environments", canPickMany: true });
 	if (!selected) {
 		return;
 	}
@@ -93,11 +94,13 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(
 		vscode.commands.registerCommand('python-tox.select', selectCommand),
 		vscode.commands.registerCommand('python-tox.selectMultiple', selectMultipleCommand),
-		vscode.commands.registerCommand('python-tox.openDocs', openDocumentationCommand)
+		vscode.commands.registerCommand('python-tox.openDocs', openDocumentationCommand),
+		vscode.languages.registerHoverProvider(['ini'], EnvironmentVariablesService.createHoverProvider())
 	);
+
 }
 
-export function deactivate() {}
+export function deactivate() { }
 
 // For testing, before we move this to a utils.ts
 export const _private = {

--- a/src/test/examples/envvars/.env
+++ b/src/test/examples/envvars/.env
@@ -1,0 +1,3 @@
+FILE_ENV_VAR_01=value_01
+FILE_ENV_VAR_02=value_02
+FILE_ENV_VAR_03=value_03

--- a/src/test/examples/envvars/.global.env
+++ b/src/test/examples/envvars/.global.env
@@ -1,0 +1,2 @@
+FILE_ENV_VAR_11=value_11
+FILE_ENV_VAR_12=value_12

--- a/src/test/examples/envvars/tox.ini
+++ b/src/test/examples/envvars/tox.ini
@@ -30,9 +30,31 @@ commands =
   echo {env:FILE_ENV_VAR_02}
   echo {env:FILE_ENV_VAR_03}
 
+[testenv:multiple_values_01]
+passenv = 
+    PWD
+    USER
+setenv =
+    file|.env
+    REGISTRY={env:REGISTRY:localhost:4243}
+    REGISTRY_USER=value_registry_user
+    REGISTRY_PWD=value_registry_pwd
+
+allowlist_externals = 
+    echo
+commands = 
+  echo {env:PWD}
+  echo {env:USER}
+  echo {env:REGISTRY_USER}
+  echo {env:FILE_ENV_VAR_01}
+  echo {env:FILE_ENV_VAR_02}
+  echo {env:FILE_ENV_VAR_03}
+
 # Changes to this file need to be reflected in the following unit tests 
 # in src/test/suite/extension.test.ts:
 # test 'update environment variables'
 # test 'get NO hover message on NO env var position'
 # test 'get hover message on env var position'
 # test 'get hover message on setenv var position'
+# test 'get hover message on setenv file reference var position'
+# test 'determine section at position in tox file'

--- a/src/test/examples/envvars/tox.ini
+++ b/src/test/examples/envvars/tox.ini
@@ -18,6 +18,8 @@ allowlist_externals =
 commands = 
   echo {env:PWD}
   echo {env:LOCALUI_OUTPUT_PATH}
+  # reference setenv variable from inherited testenv section
+  echo {env:FILE_ENV_VAR_11}
 
 [testenv:single_values_02]
 passenv = PWD
@@ -27,6 +29,8 @@ allowlist_externals =
 commands = 
   echo {env:PWD}
   echo {env:LOCALUI_OUTPUT_PATH}
+  # reference passenv variable from inherited testenv section
+  echo {env:NAME}
 
 [testenv:file_reference]
 setenv = file|.env
@@ -65,3 +69,4 @@ commands =
 # test 'get hover message on setenv var position'
 # test 'get hover message on setenv file reference var position'
 # test 'determine section at position in tox file'
+# test 'get hover message on inherited env vars from testenv'

--- a/src/test/examples/envvars/tox.ini
+++ b/src/test/examples/envvars/tox.ini
@@ -3,9 +3,18 @@ skipsdist = True
 
 # Sample how to execute this environment:
 # (export PASSENV_ENV_VAR_TEST='Hello Tox';tox -e passenv_test01)
-[testenv:single_values]
+[testenv:single_values_01]
 passenv = PWD
-setenv  = LOCALUI_OUTPUT_PATH = ./tests/.output
+setenv  = LOCALUI_OUTPUT_PATH = ./tests/.output_01
+allowlist_externals = 
+    echo
+commands = 
+  echo {env:PWD}
+  echo {env:LOCALUI_OUTPUT_PATH}
+
+[testenv:single_values_02]
+passenv = PWD
+setenv  = LOCALUI_OUTPUT_PATH = ./tests/.output_02
 allowlist_externals = 
     echo
 commands = 

--- a/src/test/examples/envvars/tox.ini
+++ b/src/test/examples/envvars/tox.ini
@@ -4,14 +4,17 @@ skipsdist = True
 # Sample how to execute this environment:
 # (export PASSENV_ENV_VAR_TEST='Hello Tox';tox -e passenv_test01)
 [testenv:passenv_test01]
-passenv = PASSENV_ENV_VAR_TEST
+passenv = PWD
+setenv  = LOCALUI_OUTPUT_PATH = ./tests/.output
 allowlist_externals = 
     echo
 commands = 
-  echo {env:PASSENV_ENV_VAR_TEST}
+  echo {env:PWD}
+  echo {env:LOCALUI_OUTPUT_PATH}
 
 # Changes to this file need to be reflected in the following unit tests 
 # in src/test/suite/extension.test.ts:
 # test 'update environment variables'
 # test 'get NO hover message on NO env var position'
 # test 'get hover message on env var position'
+# test 'get hover message on setenv var position'

--- a/src/test/examples/envvars/tox.ini
+++ b/src/test/examples/envvars/tox.ini
@@ -3,7 +3,7 @@ skipsdist = True
 
 # Sample how to execute this environment:
 # (export PASSENV_ENV_VAR_TEST='Hello Tox';tox -e passenv_test01)
-[testenv:passenv_test01]
+[testenv:single_values]
 passenv = PWD
 setenv  = LOCALUI_OUTPUT_PATH = ./tests/.output
 allowlist_externals = 
@@ -11,6 +11,15 @@ allowlist_externals =
 commands = 
   echo {env:PWD}
   echo {env:LOCALUI_OUTPUT_PATH}
+
+[testenv:file_reference]
+setenv = file|.env
+allowlist_externals = 
+    echo
+commands = 
+  echo {env:FILE_ENV_VAR_01}
+  echo {env:FILE_ENV_VAR_02}
+  echo {env:FILE_ENV_VAR_03}
 
 # Changes to this file need to be reflected in the following unit tests 
 # in src/test/suite/extension.test.ts:

--- a/src/test/examples/envvars/tox.ini
+++ b/src/test/examples/envvars/tox.ini
@@ -1,0 +1,14 @@
+# Changes to this file need to be reflected in the following unit tests 
+# in src/test/suite/extension.test.ts:
+# test 'collect environment variables'
+[tox]
+skipsdist = True
+
+# Sample how to execute this environment:
+# (export PARENT_ENV_VAR='Hello Tox';tox -e passenv_test01)
+[testenv:passenv_test01]
+passenv = PARENT_ENV_VAR
+allowlist_externals = 
+    echo
+commands = 
+  echo {env:PARENT_ENV_VAR}

--- a/src/test/examples/envvars/tox.ini
+++ b/src/test/examples/envvars/tox.ini
@@ -1,6 +1,13 @@
 [tox]
 skipsdist = True
 
+[testenv]
+passenv =
+    NAME
+setenv =
+    file|.global.env
+    TARGET_MACHINE={env:TARGET_MACHINE:localhost}
+
 # Sample how to execute this environment:
 # (export PASSENV_ENV_VAR_TEST='Hello Tox';tox -e passenv_test01)
 [testenv:single_values_01]

--- a/src/test/examples/envvars/tox.ini
+++ b/src/test/examples/envvars/tox.ini
@@ -1,14 +1,17 @@
-# Changes to this file need to be reflected in the following unit tests 
-# in src/test/suite/extension.test.ts:
-# test 'collect environment variables'
 [tox]
 skipsdist = True
 
 # Sample how to execute this environment:
-# (export PARENT_ENV_VAR='Hello Tox';tox -e passenv_test01)
+# (export PASSENV_ENV_VAR_TEST='Hello Tox';tox -e passenv_test01)
 [testenv:passenv_test01]
-passenv = PARENT_ENV_VAR
+passenv = PASSENV_ENV_VAR_TEST
 allowlist_externals = 
     echo
 commands = 
-  echo {env:PARENT_ENV_VAR}
+  echo {env:PASSENV_ENV_VAR_TEST}
+
+# Changes to this file need to be reflected in the following unit tests 
+# in src/test/suite/extension.test.ts:
+# test 'update environment variables'
+# test 'get NO hover message on NO env var position'
+# test 'get hover message on env var position'

--- a/src/test/examples/simple/tox.ini
+++ b/src/test/examples/simple/tox.ini
@@ -3,6 +3,7 @@ skipsdist = True
 
 [testenv:one]
 commands = {envpython} -c "print('one')"
+passenv = PARENT_ENV_VAR
 
 [testenv:two]
 commands = {envpython} -c "print('two')"

--- a/src/test/examples/simple/tox.ini
+++ b/src/test/examples/simple/tox.ini
@@ -3,7 +3,6 @@ skipsdist = True
 
 [testenv:one]
 commands = {envpython} -c "print('one')"
-passenv = PARENT_ENV_VAR
 
 [testenv:two]
 commands = {envpython} -c "print('two')"

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -81,7 +81,8 @@ suite('Extension Test Suite', () => {
     const toxIniContent = fs.readFileSync(toxIniPath,'utf8');
     when(mockedTextDocument.getText()).thenReturn(toxIniContent);
 
-    let result = EnvironmentVariablesService.collectEnvironmentVariables(instance(mockedTextDocument));
+		const environmentVariablesService = new EnvironmentVariablesService();
+    let result = environmentVariablesService.collectEnvironmentVariables(instance(mockedTextDocument));
 
     assert.equal(result.get("passenv"), "PARENT_ENV_VAR");
 		

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -95,8 +95,8 @@ suite('Extension Test Suite', () => {
 		// Act
 
 		const environmentVariablesService = new EnvironmentVariablesService();
-		let resultUpdate = environmentVariablesService.updateAllEnvironmentVariables(textDocument);
-		let hoverMessage = environmentVariablesService.generateHoverMessage(textDocument, position);
+		const resultUpdate = environmentVariablesService.updateAllEnvironmentVariables(textDocument);
+		const hoverMessage = environmentVariablesService.generateHoverMessage(textDocument, position);
 
 		// Assert
 
@@ -117,8 +117,8 @@ suite('Extension Test Suite', () => {
 		// Act
 
 		const environmentVariablesService = new EnvironmentVariablesService();
-		let resultUpdate = environmentVariablesService.updateAllEnvironmentVariables(textDocument);
-		let hoverMessage = environmentVariablesService.generateHoverMessage(textDocument, position);
+		const resultUpdate = environmentVariablesService.updateAllEnvironmentVariables(textDocument);
+		const hoverMessage = environmentVariablesService.generateHoverMessage(textDocument, position);
 
 		// Assert
 
@@ -145,8 +145,8 @@ suite('Extension Test Suite', () => {
 		// Act
 
 		const environmentVariablesService = new EnvironmentVariablesService();
-		let resultUpdate = environmentVariablesService.updateAllEnvironmentVariables(textDocument);
-		let hoverMessage = environmentVariablesService.generateHoverMessage(textDocument, position);
+		const resultUpdate = environmentVariablesService.updateAllEnvironmentVariables(textDocument);
+		const hoverMessage = environmentVariablesService.generateHoverMessage(textDocument, position);
 
 		// Assert
 
@@ -170,8 +170,8 @@ suite('Extension Test Suite', () => {
 		// Act
 
 		const environmentVariablesService = new EnvironmentVariablesService();
-		let resultUpdate = environmentVariablesService.updateAllEnvironmentVariables(textDocument);
-		let hoverMessage = environmentVariablesService.generateHoverMessage(textDocument, position);
+		const resultUpdate = environmentVariablesService.updateAllEnvironmentVariables(textDocument);
+		const hoverMessage = environmentVariablesService.generateHoverMessage(textDocument, position);
 
 		// Assert
 
@@ -180,6 +180,42 @@ suite('Extension Test Suite', () => {
 
 		const expectedHoverMessage = "FILE_ENV_VAR_02: 'value_02'";
 		assert.equal(hoverMessage && hoverMessage[0].value, expectedHoverMessage, `For the given position the expected hover message is: '${expectedHoverMessage}'.`);
+	});
+
+
+	test('determine section at position in tox file', async () => {
+		// Arrange
+		// A text document containing a sample tox.ini file.
+		const toxIniPath = getExampleToxIniPath("envvars");
+		const textDocument = await vscode.workspace.openTextDocument(toxIniPath);
+
+		// A position which DOES reference a variable set by passenv or setenv.
+		// Properties line and character in Position are zero-based, VS Code UI is one-based.
+		const position1 = new vscode.Position(10, 10);	// section testenv:single_values
+		const position2 = new vscode.Position(20, 20);	// section testenv:file_reference
+		const position3 = new vscode.Position(5, 15);	// in the middle of section name testenv:single_values
+		const position4 = new vscode.Position(100, 100);	// outside of document scope
+
+		// Act
+
+		const environmentVariablesService = new EnvironmentVariablesService();
+		const sectionName1 = environmentVariablesService.determineSection(textDocument, position1);
+		const sectionName2 = environmentVariablesService.determineSection(textDocument, position2);
+		const sectionName3 = environmentVariablesService.determineSection(textDocument, position3);
+		const sectionName4 = environmentVariablesService.determineSection(textDocument, position4);
+
+		// Assert
+
+		const expectedSectionName1 = 'testenv:single_values';
+		const expectedSectionName2 = 'testenv:file_reference';
+		const expectedSectionName3 = 'testenv:single_values';
+		const expectedSectionName4 = 'testenv:file_reference';
+
+		assert.equal(sectionName1, expectedSectionName1, `For the given position the expected section name is: '${expectedSectionName1}'.`);
+		assert.equal(sectionName2, expectedSectionName2, `For the given position the expected section name is: '${expectedSectionName2}'.`);
+		assert.equal(sectionName3, expectedSectionName3, `For the given position the expected section name is: '${expectedSectionName3}'.`);
+		assert.equal(sectionName4, expectedSectionName4, `For the given position the expected section name is: '${expectedSectionName4}'.`);
+
 	});
 
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -119,7 +119,7 @@ suite('Extension Test Suite', () => {
 		// A position which DOES reference a variable set by passenv.
 		// Properties line and character in Position are zero-based, VS Code UI is one-based.
 		const position1 = new vscode.Position(18, 13); // point to variable PWD in section testenv:single_values_01
-		const position2 = new vscode.Position(53, 15); // point to variable USER in section testenv:multiple_values_01
+		const position2 = new vscode.Position(57, 15); // point to variable USER in section testenv:multiple_values_01
 
 		// Act
 
@@ -157,8 +157,8 @@ suite('Extension Test Suite', () => {
 		// A position which DOES reference a variable set by setenv.
 		// Properties line and character in Position are zero-based, VS Code UI is one-based.
 		const position1 = new vscode.Position(19, 20);	// point to variable LOCALUI_OUTPUT_PATH in section testenv:single_values_01
-		const position2 = new vscode.Position(28, 20);	// point to variable LOCALUI_OUTPUT_PATH in section testenv:single_values_02
-		const position3 = new vscode.Position(54, 20);	// point to variable REGISTRY_USER in section testenv:multiple_values_01
+		const position2 = new vscode.Position(30, 20);	// point to variable LOCALUI_OUTPUT_PATH in section testenv:single_values_02
+		const position3 = new vscode.Position(58, 20);	// point to variable REGISTRY_USER in section testenv:multiple_values_01
 
 		// Act
 
@@ -193,10 +193,10 @@ suite('Extension Test Suite', () => {
 		const toxIniPath = getExampleToxIniPath("envvars");
 		const textDocument = await vscode.workspace.openTextDocument(toxIniPath);
 
-		// A position which DOES reference a variable set by passenv or setenv.
+		// A position which DOES reference a variable set by setenv.
 		// Properties line and character in Position are zero-based, VS Code UI is one-based.
-		const position1 = new vscode.Position(36, 20);	// point to variable FILE_ENV_VAR_02 in section testenv:file_reference
-		const position2 = new vscode.Position(57, 20);	// point to variable FILE_ENV_VAR_03 in section testenv:multiple_values_01
+		const position1 = new vscode.Position(40, 20);	// point to variable FILE_ENV_VAR_02 in section testenv:file_reference
+		const position2 = new vscode.Position(61, 20);	// point to variable FILE_ENV_VAR_03 in section testenv:multiple_values_01
 
 		// Act
 
@@ -227,12 +227,11 @@ suite('Extension Test Suite', () => {
 		const toxIniPath = getExampleToxIniPath("envvars");
 		const textDocument = await vscode.workspace.openTextDocument(toxIniPath);
 
-		// A position which DOES reference a variable set by passenv or setenv.
 		// Properties line and character in Position are zero-based, VS Code UI is one-based.
 		const position1 = new vscode.Position(16, 10);	// point somewhere into section testenv:single_values_01
-		const position2 = new vscode.Position(32, 10);	// point somewhere into section testenv:file_reference
+		const position2 = new vscode.Position(36, 10);	// point somewhere into section testenv:file_reference
 		const position3 = new vscode.Position(12, 15);	// point into in the middle of section name testenv:single_values_01
-		const position4 = new vscode.Position(56, 15);	// point into in the middle of section name testenv:multiple_values_01
+		const position4 = new vscode.Position(60, 15);	// point into in the middle of section name testenv:multiple_values_01
 		const position5 = new vscode.Position(100, 100);	// point outside of document
 
 		// Act
@@ -257,6 +256,42 @@ suite('Extension Test Suite', () => {
 		assert.equal(sectionName3, expectedSectionName3, `For the given position the expected section name is: '${expectedSectionName3}'.`);
 		assert.equal(sectionName4, expectedSectionName4, `For the given position the expected section name is: '${expectedSectionName4}'.`);
 		assert.equal(sectionName5, expectedSectionName5, `For the given position the expected section name is: '${expectedSectionName5}'.`);
+
+	});
+
+	test('get hover message on inherited env vars from testenv', async () => {
+		// Arrange
+		// A text document containing a sample tox.ini file.
+		const toxIniPath = getExampleToxIniPath("envvars");
+		const textDocument = await vscode.workspace.openTextDocument(toxIniPath);
+
+		// A position which DOES reference a variable set by passenv or setenv.
+		// Properties line and character in Position are zero-based, VS Code UI is one-based.
+		const position1 = new vscode.Position(21, 20);	// point to variable FILE_ENV_VAR_11 in section testenv:single_values_01
+		const position2 = new vscode.Position(32, 15);	// point to variable NAME in section testenv:single_values_02
+
+		// Act
+
+		const environmentVariablesService = new EnvironmentVariablesService();
+		const resultUpdate = environmentVariablesService.analyzeDocument(textDocument);
+
+		const hoverMessage1 = environmentVariablesService.generateHoverMessage(textDocument, position1);
+		const hoverMessage2 = environmentVariablesService.generateHoverMessage(textDocument, position2);
+
+		// Assert
+
+		assert.equal(resultUpdate, true, 'Environment variables in the sample tox.ini file should have been found.');
+		assert.notEqual(hoverMessage1, null);
+		assert.notEqual(hoverMessage2, null);
+
+		const expectedHoverMessage1 = constructExpectedHoverMessage("testenv", "FILE_ENV_VAR_11", "value_11");
+		assert.equal(hoverMessage1 && hoverMessage1[0].value, expectedHoverMessage1, `For the given position the expected hover message is: '${expectedHoverMessage1}'.`);
+
+		const testPassEnvName = "NAME";
+		const testPassEnvValue = process.env[testPassEnvName] ?? "";
+		const expectedHoverMessage2 = constructExpectedHoverMessage("testenv", testPassEnvName, testPassEnvValue);
+
+		assert.equal(hoverMessage2 && hoverMessage2[0].value, expectedHoverMessage2, `For the given position the expected hover message is: '${expectedHoverMessage2}'.`);
 
 	});
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -238,11 +238,11 @@ suite('Extension Test Suite', () => {
 		// Act
 
 		const environmentVariablesService = new EnvironmentVariablesService();
-		const sectionName1 = environmentVariablesService.determineSection(textDocument, position1);
-		const sectionName2 = environmentVariablesService.determineSection(textDocument, position2);
-		const sectionName3 = environmentVariablesService.determineSection(textDocument, position3);
-		const sectionName4 = environmentVariablesService.determineSection(textDocument, position4);
-		const sectionName5 = environmentVariablesService.determineSection(textDocument, position5);
+		const sectionName1 = EnvironmentVariablesService.determineSection(textDocument, position1);
+		const sectionName2 = EnvironmentVariablesService.determineSection(textDocument, position2);
+		const sectionName3 = EnvironmentVariablesService.determineSection(textDocument, position3);
+		const sectionName4 = EnvironmentVariablesService.determineSection(textDocument, position4);
+		const sectionName5 = EnvironmentVariablesService.determineSection(textDocument, position5);
 
 		// Assert
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -84,7 +84,8 @@ suite('Extension Test Suite', () => {
 		const environmentVariablesService = new EnvironmentVariablesService();
     let result = environmentVariablesService.updateEnvironmentVariables(instance(mockedTextDocument));
 
-    assert.equal(result.get("passenv"), "PARENT_ENV_VAR");
+		assert.equal(result, true);
+    assert.equal(environmentVariablesService.environmentVariables.get("passenv"), "PARENT_ENV_VAR");
 		
     verify(mockedTextDocument.getText()).called();
 	});

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,5 +1,3 @@
-import { strict as assert } from 'assert';
-
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
@@ -8,6 +6,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { EnvironmentVariablesService } from '../../environment_variables_service';
 import { mock, verify, instance, when } from 'ts-mockito';
+import { strict as assert } from 'assert';
 
 function getExampleDir(name: string) {
 	const dir = path.join(__dirname, '..', '..', '..', 'src', 'test', 'examples', name);
@@ -151,7 +150,7 @@ suite('Extension Test Suite', () => {
 		let hoverMessage = environmentVariablesService.generateHoverMessage(textDocument, position);
 
 		// Assert
-		
+
 		assert.equal(resultUpdate, true, 'Environment variables in the sample tox.ini file should have been found.');
 		assert.notEqual(hoverMessage, null);
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -90,12 +90,12 @@ suite('Extension Test Suite', () => {
 
 		// A position which DOES NOT reference a variable set by passenv or setenv.
 		// Properties line and character in Position are zero-based, VS Code UI is one-based.
-		const position = new vscode.Position(1, 4);
+		const position = new vscode.Position(1, 4);	// point to a position without a variable name
 
 		// Act
 
 		const environmentVariablesService = new EnvironmentVariablesService();
-		const resultUpdate = environmentVariablesService.updateAllEnvironmentVariables(textDocument);
+		const resultUpdate = environmentVariablesService.analyzeDocument(textDocument);
 		const hoverMessage = environmentVariablesService.generateHoverMessage(textDocument, position);
 
 		// Assert
@@ -112,12 +112,12 @@ suite('Extension Test Suite', () => {
 
 		// A position which DOES reference a variable set by passenv or setenv.
 		// Properties line and character in Position are zero-based, VS Code UI is one-based.
-		const position = new vscode.Position(11, 13);
+		const position = new vscode.Position(11, 13); // point to variable PWD in section testenv:single_values_01
 
 		// Act
 
 		const environmentVariablesService = new EnvironmentVariablesService();
-		const resultUpdate = environmentVariablesService.updateAllEnvironmentVariables(textDocument);
+		const resultUpdate = environmentVariablesService.analyzeDocument(textDocument);
 		const hoverMessage = environmentVariablesService.generateHoverMessage(textDocument, position);
 
 		// Assert
@@ -140,21 +140,27 @@ suite('Extension Test Suite', () => {
 
 		// A position which DOES reference a variable set by passenv or setenv.
 		// Properties line and character in Position are zero-based, VS Code UI is one-based.
-		const position = new vscode.Position(12, 20);
+		const position1 = new vscode.Position(12, 20);	// point to variable LOCALUI_OUTPUT_PATH in section testenv:single_values_01
+		const position2 = new vscode.Position(16, 20);	// point to variable LOCALUI_OUTPUT_PATH in section testenv:single_values_02
 
 		// Act
 
 		const environmentVariablesService = new EnvironmentVariablesService();
-		const resultUpdate = environmentVariablesService.updateAllEnvironmentVariables(textDocument);
-		const hoverMessage = environmentVariablesService.generateHoverMessage(textDocument, position);
+		const resultUpdate = environmentVariablesService.analyzeDocument(textDocument);
+
+		const hoverMessage1 = environmentVariablesService.generateHoverMessage(textDocument, position1);
+		const hoverMessage2 = environmentVariablesService.generateHoverMessage(textDocument, position2);
 
 		// Assert
 
 		assert.equal(resultUpdate, true, 'Environment variables in the sample tox.ini file should have been found.');
-		assert.notEqual(hoverMessage, null);
+		assert.notEqual(hoverMessage1, null);
 
-		const expectedHoverMessage = "LOCALUI_OUTPUT_PATH: './tests/.output'";
-		assert.equal(hoverMessage && hoverMessage[0].value, expectedHoverMessage, `For the given position the expected hover message is: '${expectedHoverMessage}'.`);
+		const expectedHoverMessage1 = "LOCALUI_OUTPUT_PATH: './tests/.output_01'";
+		assert.equal(hoverMessage1 && hoverMessage1[0].value, expectedHoverMessage1, `For the given position the expected hover message is: '${expectedHoverMessage1}'.`);
+
+		const expectedHoverMessage2 = "LOCALUI_OUTPUT_PATH: './tests/.output_02'";
+		assert.equal(hoverMessage2 && hoverMessage2[0].value, expectedHoverMessage2, `For the given position the expected hover message is: '${expectedHoverMessage2}'.`);
 	});
 
 	test('get hover message on setenv file reference var position', async () => {
@@ -165,12 +171,12 @@ suite('Extension Test Suite', () => {
 
 		// A position which DOES reference a variable set by passenv or setenv.
 		// Properties line and character in Position are zero-based, VS Code UI is one-based.
-		const position = new vscode.Position(20, 20);
+		const position = new vscode.Position(29, 20);	// point to variable FILE_ENV_VAR_02 in section testenv:file_reference
 
 		// Act
 
 		const environmentVariablesService = new EnvironmentVariablesService();
-		const resultUpdate = environmentVariablesService.updateAllEnvironmentVariables(textDocument);
+		const resultUpdate = environmentVariablesService.analyzeDocument(textDocument);
 		const hoverMessage = environmentVariablesService.generateHoverMessage(textDocument, position);
 
 		// Assert
@@ -191,10 +197,10 @@ suite('Extension Test Suite', () => {
 
 		// A position which DOES reference a variable set by passenv or setenv.
 		// Properties line and character in Position are zero-based, VS Code UI is one-based.
-		const position1 = new vscode.Position(10, 10);	// section testenv:single_values
-		const position2 = new vscode.Position(20, 20);	// section testenv:file_reference
-		const position3 = new vscode.Position(5, 15);	// in the middle of section name testenv:single_values
-		const position4 = new vscode.Position(100, 100);	// outside of document scope
+		const position1 = new vscode.Position(10, 10);	// point somewhere into section testenv:single_values_01
+		const position2 = new vscode.Position(25, 10);	// point somewhere into section testenv:file_reference
+		const position3 = new vscode.Position(5, 15);	// point into in the middle of section name testenv:single_values_01
+		const position4 = new vscode.Position(100, 100);	// point outside of document
 
 		// Act
 
@@ -206,9 +212,9 @@ suite('Extension Test Suite', () => {
 
 		// Assert
 
-		const expectedSectionName1 = 'testenv:single_values';
+		const expectedSectionName1 = 'testenv:single_values_01';
 		const expectedSectionName2 = 'testenv:file_reference';
-		const expectedSectionName3 = 'testenv:single_values';
+		const expectedSectionName3 = 'testenv:single_values_01';
 		const expectedSectionName4 = 'testenv:file_reference';
 
 		assert.equal(sectionName1, expectedSectionName1, `For the given position the expected section name is: '${expectedSectionName1}'.`);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -82,7 +82,7 @@ suite('Extension Test Suite', () => {
     when(mockedTextDocument.getText()).thenReturn(toxIniContent);
 
 		const environmentVariablesService = new EnvironmentVariablesService();
-    let result = environmentVariablesService.collectEnvironmentVariables(instance(mockedTextDocument));
+    let result = environmentVariablesService.updateEnvironmentVariables(instance(mockedTextDocument));
 
     assert.equal(result.get("passenv"), "PARENT_ENV_VAR");
 		

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -110,38 +110,10 @@ suite('Extension Test Suite', () => {
 		const toxIniPath = getExampleToxIniPath("envvars");
 		const textDocument = await vscode.workspace.openTextDocument(toxIniPath);
 
-		// A position which DOES reference a variable set by passenv or setenv.
+		// A position which DOES reference a variable set by passenv.
 		// Properties line and character in Position are zero-based, VS Code UI is one-based.
-		const position = new vscode.Position(11, 13); // point to variable PWD in section testenv:single_values_01
-
-		// Act
-
-		const environmentVariablesService = new EnvironmentVariablesService();
-		const resultUpdate = environmentVariablesService.analyzeDocument(textDocument);
-		const hoverMessage = environmentVariablesService.generateHoverMessage(textDocument, position);
-
-		// Assert
-
-		assert.equal(resultUpdate, true, 'Environment variables in the sample tox.ini file should have been found.');
-		assert.notEqual(hoverMessage, null);
-
-		const testPassEnvName = "PWD";
-		const testPassEnvValue = process.env[testPassEnvName];
-		const expectedHoverMessage = `[testenv:single_values_01] ${testPassEnvName}: '${testPassEnvValue}'`;
-
-		assert.equal(hoverMessage && hoverMessage[0].value, expectedHoverMessage, `For the given position the expected hover message is: '${expectedHoverMessage}'.`);
-	});
-
-	test('get hover message on setenv var position', async () => {
-		// Arrange
-		// A text document containing a sample tox.ini file.
-		const toxIniPath = getExampleToxIniPath("envvars");
-		const textDocument = await vscode.workspace.openTextDocument(toxIniPath);
-
-		// A position which DOES reference a variable set by passenv or setenv.
-		// Properties line and character in Position are zero-based, VS Code UI is one-based.
-		const position1 = new vscode.Position(12, 20);	// point to variable LOCALUI_OUTPUT_PATH in section testenv:single_values_01
-		const position2 = new vscode.Position(16, 20);	// point to variable LOCALUI_OUTPUT_PATH in section testenv:single_values_02
+		const position1 = new vscode.Position(11, 13); // point to variable PWD in section testenv:single_values_01
+		const position2 = new vscode.Position(46, 15); // point to variable USER in section testenv:multiple_values_01
 
 		// Act
 
@@ -155,12 +127,58 @@ suite('Extension Test Suite', () => {
 
 		assert.equal(resultUpdate, true, 'Environment variables in the sample tox.ini file should have been found.');
 		assert.notEqual(hoverMessage1, null);
+		assert.notEqual(hoverMessage2, null);
+
+		const testPassEnvName1 = "PWD";
+		const testPassEnvValue1 = process.env[testPassEnvName1];
+		const expectedHoverMessage1 = `[testenv:single_values_01] ${testPassEnvName1}: '${testPassEnvValue1}'`;
+
+		assert.equal(hoverMessage1 && hoverMessage1[0].value, expectedHoverMessage1, `For the given position the expected hover message is: '${expectedHoverMessage1}'.`);
+
+		const testPassEnvName2 = "USER";
+		const testPassEnvValue2 = process.env[testPassEnvName2];
+		const expectedHoverMessage2 = `[testenv:multiple_values_01] ${testPassEnvName2}: '${testPassEnvValue2}'`;
+
+		assert.equal(hoverMessage2 && hoverMessage2[0].value, expectedHoverMessage2, `For the given position the expected hover message is: '${expectedHoverMessage2}'.`);
+	});
+
+	test('get hover message on setenv var position', async () => {
+		// Arrange
+		// A text document containing a sample tox.ini file.
+		const toxIniPath = getExampleToxIniPath("envvars");
+		const textDocument = await vscode.workspace.openTextDocument(toxIniPath);
+
+		// A position which DOES reference a variable set by setenv.
+		// Properties line and character in Position are zero-based, VS Code UI is one-based.
+		const position1 = new vscode.Position(12, 20);	// point to variable LOCALUI_OUTPUT_PATH in section testenv:single_values_01
+		const position2 = new vscode.Position(16, 20);	// point to variable LOCALUI_OUTPUT_PATH in section testenv:single_values_02
+		const position3 = new vscode.Position(47, 20);	// point to variable REGISTRY_USER in section testenv:multiple_values_01
+
+		// Act
+
+		const environmentVariablesService = new EnvironmentVariablesService();
+		const resultUpdate = environmentVariablesService.analyzeDocument(textDocument);
+
+		const hoverMessage1 = environmentVariablesService.generateHoverMessage(textDocument, position1);
+		const hoverMessage2 = environmentVariablesService.generateHoverMessage(textDocument, position2);
+		const hoverMessage3 = environmentVariablesService.generateHoverMessage(textDocument, position3);
+
+		// Assert
+
+		assert.equal(resultUpdate, true, 'Environment variables in the sample tox.ini file should have been found.');
+		assert.notEqual(hoverMessage1, null);
+		assert.notEqual(hoverMessage2, null);
+		assert.notEqual(hoverMessage3, null);
 
 		const expectedHoverMessage1 = "[testenv:single_values_01] LOCALUI_OUTPUT_PATH: './tests/.output_01'";
 		assert.equal(hoverMessage1 && hoverMessage1[0].value, expectedHoverMessage1, `For the given position the expected hover message is: '${expectedHoverMessage1}'.`);
 
 		const expectedHoverMessage2 = "[testenv:single_values_02] LOCALUI_OUTPUT_PATH: './tests/.output_02'";
 		assert.equal(hoverMessage2 && hoverMessage2[0].value, expectedHoverMessage2, `For the given position the expected hover message is: '${expectedHoverMessage2}'.`);
+
+		const expectedHoverMessage3 = "[testenv:multiple_values_01] REGISTRY_USER: 'value_registry_user'";
+		assert.equal(hoverMessage3 && hoverMessage3[0].value, expectedHoverMessage3, `For the given position the expected hover message is: '${expectedHoverMessage3}'.`);
+
 	});
 
 	test('get hover message on setenv file reference var position', async () => {
@@ -171,21 +189,29 @@ suite('Extension Test Suite', () => {
 
 		// A position which DOES reference a variable set by passenv or setenv.
 		// Properties line and character in Position are zero-based, VS Code UI is one-based.
-		const position = new vscode.Position(29, 20);	// point to variable FILE_ENV_VAR_02 in section testenv:file_reference
+		const position1 = new vscode.Position(29, 20);	// point to variable FILE_ENV_VAR_02 in section testenv:file_reference
+		const position2 = new vscode.Position(50, 20);	// point to variable FILE_ENV_VAR_03 in section testenv:multiple_values_01
 
 		// Act
 
 		const environmentVariablesService = new EnvironmentVariablesService();
 		const resultUpdate = environmentVariablesService.analyzeDocument(textDocument);
-		const hoverMessage = environmentVariablesService.generateHoverMessage(textDocument, position);
+
+		const hoverMessage1 = environmentVariablesService.generateHoverMessage(textDocument, position1);
+		const hoverMessage2 = environmentVariablesService.generateHoverMessage(textDocument, position2);
 
 		// Assert
 
 		assert.equal(resultUpdate, true, 'Environment variables in the sample tox.ini file should have been found.');
-		assert.notEqual(hoverMessage, null);
+		assert.notEqual(hoverMessage1, null);
+		assert.notEqual(hoverMessage2, null);
 
-		const expectedHoverMessage = "[testenv:file_reference] FILE_ENV_VAR_02: 'value_02'";
-		assert.equal(hoverMessage && hoverMessage[0].value, expectedHoverMessage, `For the given position the expected hover message is: '${expectedHoverMessage}'.`);
+		const expectedHoverMessage1 = "[testenv:file_reference] FILE_ENV_VAR_02: 'value_02'";
+		assert.equal(hoverMessage1 && hoverMessage1[0].value, expectedHoverMessage1, `For the given position the expected hover message is: '${expectedHoverMessage1}'.`);
+
+		const expectedHoverMessage2 = "[testenv:multiple_values_01] FILE_ENV_VAR_03: 'value_03'";
+		assert.equal(hoverMessage2 && hoverMessage2[0].value, expectedHoverMessage2, `For the given position the expected hover message is: '${expectedHoverMessage2}'.`);
+
 	});
 
 
@@ -200,7 +226,8 @@ suite('Extension Test Suite', () => {
 		const position1 = new vscode.Position(10, 10);	// point somewhere into section testenv:single_values_01
 		const position2 = new vscode.Position(25, 10);	// point somewhere into section testenv:file_reference
 		const position3 = new vscode.Position(5, 15);	// point into in the middle of section name testenv:single_values_01
-		const position4 = new vscode.Position(100, 100);	// point outside of document
+		const position4 = new vscode.Position(50, 15);	// point into in the middle of section name testenv:multiple_values_01
+		const position5 = new vscode.Position(100, 100);	// point outside of document
 
 		// Act
 
@@ -209,18 +236,21 @@ suite('Extension Test Suite', () => {
 		const sectionName2 = environmentVariablesService.determineSection(textDocument, position2);
 		const sectionName3 = environmentVariablesService.determineSection(textDocument, position3);
 		const sectionName4 = environmentVariablesService.determineSection(textDocument, position4);
+		const sectionName5 = environmentVariablesService.determineSection(textDocument, position5);
 
 		// Assert
 
 		const expectedSectionName1 = 'testenv:single_values_01';
 		const expectedSectionName2 = 'testenv:file_reference';
 		const expectedSectionName3 = 'testenv:single_values_01';
-		const expectedSectionName4 = 'testenv:file_reference';
+		const expectedSectionName4 = 'testenv:multiple_values_01';
+		const expectedSectionName5 = 'testenv:multiple_values_01';
 
 		assert.equal(sectionName1, expectedSectionName1, `For the given position the expected section name is: '${expectedSectionName1}'.`);
 		assert.equal(sectionName2, expectedSectionName2, `For the given position the expected section name is: '${expectedSectionName2}'.`);
 		assert.equal(sectionName3, expectedSectionName3, `For the given position the expected section name is: '${expectedSectionName3}'.`);
 		assert.equal(sectionName4, expectedSectionName4, `For the given position the expected section name is: '${expectedSectionName4}'.`);
+		assert.equal(sectionName5, expectedSectionName5, `For the given position the expected section name is: '${expectedSectionName5}'.`);
 
 	});
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -6,7 +6,8 @@ import * as vscode from 'vscode';
 import * as extension from '../../extension';
 import * as path from 'path';
 import * as fs from 'fs';
-import * as util from 'util';
+import { EnvironmentVariablesService } from '../../environment_variables_service';
+import {mock, verify, instance, when} from 'ts-mockito';
 
 function getExampleDir(name: string) {
 	const dir = path.join(__dirname, '..', '..', '..', 'src', 'test', 'examples', name);
@@ -70,4 +71,21 @@ suite('Extension Test Suite', () => {
 		await waitForMarker(tmpdir);
 		assert.ok(fs.existsSync(marker));
 	});
+
+	test('collect environment variables', async () => {
+    let mockedTextDocument : vscode.TextDocument = mock<vscode.TextDocument>();
+
+    // stub method before execution
+		const exampleDir = getExampleDir("simple");
+		const toxIniPath = path.join(exampleDir, 'tox.ini');
+    const toxIniContent = fs.readFileSync(toxIniPath,'utf8');
+    when(mockedTextDocument.getText()).thenReturn(toxIniContent);
+
+    let result = EnvironmentVariablesService.collectEnvironmentVariables(instance(mockedTextDocument));
+
+    assert.equal(result.get("passenv"), "PARENT_ENV_VAR");
+		
+    verify(mockedTextDocument.getText()).called();
+	});
+
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -127,7 +127,7 @@ suite('Extension Test Suite', () => {
 
 		const testPassEnvName = "PWD";
 		const testPassEnvValue = process.env[testPassEnvName];
-		const expectedHoverMessage = `${testPassEnvName}: '${testPassEnvValue}'`;
+		const expectedHoverMessage = `[testenv:single_values_01] ${testPassEnvName}: '${testPassEnvValue}'`;
 
 		assert.equal(hoverMessage && hoverMessage[0].value, expectedHoverMessage, `For the given position the expected hover message is: '${expectedHoverMessage}'.`);
 	});
@@ -156,10 +156,10 @@ suite('Extension Test Suite', () => {
 		assert.equal(resultUpdate, true, 'Environment variables in the sample tox.ini file should have been found.');
 		assert.notEqual(hoverMessage1, null);
 
-		const expectedHoverMessage1 = "LOCALUI_OUTPUT_PATH: './tests/.output_01'";
+		const expectedHoverMessage1 = "[testenv:single_values_01] LOCALUI_OUTPUT_PATH: './tests/.output_01'";
 		assert.equal(hoverMessage1 && hoverMessage1[0].value, expectedHoverMessage1, `For the given position the expected hover message is: '${expectedHoverMessage1}'.`);
 
-		const expectedHoverMessage2 = "LOCALUI_OUTPUT_PATH: './tests/.output_02'";
+		const expectedHoverMessage2 = "[testenv:single_values_02] LOCALUI_OUTPUT_PATH: './tests/.output_02'";
 		assert.equal(hoverMessage2 && hoverMessage2[0].value, expectedHoverMessage2, `For the given position the expected hover message is: '${expectedHoverMessage2}'.`);
 	});
 
@@ -184,7 +184,7 @@ suite('Extension Test Suite', () => {
 		assert.equal(resultUpdate, true, 'Environment variables in the sample tox.ini file should have been found.');
 		assert.notEqual(hoverMessage, null);
 
-		const expectedHoverMessage = "FILE_ENV_VAR_02: 'value_02'";
+		const expectedHoverMessage = "[testenv:file_reference] FILE_ENV_VAR_02: 'value_02'";
 		assert.equal(hoverMessage && hoverMessage[0].value, expectedHoverMessage, `For the given position the expected hover message is: '${expectedHoverMessage}'.`);
 	});
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -76,7 +76,7 @@ suite('Extension Test Suite', () => {
     let mockedTextDocument : vscode.TextDocument = mock<vscode.TextDocument>();
 
     // stub method before execution
-		const exampleDir = getExampleDir("simple");
+		const exampleDir = getExampleDir("envvars");
 		const toxIniPath = path.join(exampleDir, 'tox.ini');
     const toxIniContent = fs.readFileSync(toxIniPath,'utf8');
     when(mockedTextDocument.getText()).thenReturn(toxIniContent);

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -157,5 +157,29 @@ suite('Extension Test Suite', () => {
 		assert.equal(hoverMessage && hoverMessage[0].value, expectedHoverMessage, `For the given position the expected hover message is: '${expectedHoverMessage}'.`);
 	});
 
+	test('get hover message on setenv file reference var position', async () => {
+		// Arrange
+		// A text document containing a sample tox.ini file.
+		const toxIniPath = getExampleToxIniPath("envvars");
+		const textDocument = await vscode.workspace.openTextDocument(toxIniPath);
+
+		// A position which DOES reference a variable set by passenv or setenv.
+		// Properties line and character in Position are zero-based, VS Code UI is one-based.
+		const position = new vscode.Position(20, 20);
+
+		// Act
+
+		const environmentVariablesService = new EnvironmentVariablesService();
+		let resultUpdate = environmentVariablesService.updateAllEnvironmentVariables(textDocument);
+		let hoverMessage = environmentVariablesService.generateHoverMessage(textDocument, position);
+
+		// Assert
+
+		assert.equal(resultUpdate, true, 'Environment variables in the sample tox.ini file should have been found.');
+		assert.notEqual(hoverMessage, null);
+
+		const expectedHoverMessage = "FILE_ENV_VAR_02: 'value_02'";
+		assert.equal(hoverMessage && hoverMessage[0].value, expectedHoverMessage, `For the given position the expected hover message is: '${expectedHoverMessage}'.`);
+	});
 
 });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -118,8 +118,8 @@ suite('Extension Test Suite', () => {
 
 		// A position which DOES reference a variable set by passenv.
 		// Properties line and character in Position are zero-based, VS Code UI is one-based.
-		const position1 = new vscode.Position(11, 13); // point to variable PWD in section testenv:single_values_01
-		const position2 = new vscode.Position(46, 15); // point to variable USER in section testenv:multiple_values_01
+		const position1 = new vscode.Position(18, 13); // point to variable PWD in section testenv:single_values_01
+		const position2 = new vscode.Position(53, 15); // point to variable USER in section testenv:multiple_values_01
 
 		// Act
 
@@ -156,9 +156,9 @@ suite('Extension Test Suite', () => {
 
 		// A position which DOES reference a variable set by setenv.
 		// Properties line and character in Position are zero-based, VS Code UI is one-based.
-		const position1 = new vscode.Position(12, 20);	// point to variable LOCALUI_OUTPUT_PATH in section testenv:single_values_01
-		const position2 = new vscode.Position(16, 20);	// point to variable LOCALUI_OUTPUT_PATH in section testenv:single_values_02
-		const position3 = new vscode.Position(47, 20);	// point to variable REGISTRY_USER in section testenv:multiple_values_01
+		const position1 = new vscode.Position(19, 20);	// point to variable LOCALUI_OUTPUT_PATH in section testenv:single_values_01
+		const position2 = new vscode.Position(28, 20);	// point to variable LOCALUI_OUTPUT_PATH in section testenv:single_values_02
+		const position3 = new vscode.Position(54, 20);	// point to variable REGISTRY_USER in section testenv:multiple_values_01
 
 		// Act
 
@@ -195,8 +195,8 @@ suite('Extension Test Suite', () => {
 
 		// A position which DOES reference a variable set by passenv or setenv.
 		// Properties line and character in Position are zero-based, VS Code UI is one-based.
-		const position1 = new vscode.Position(29, 20);	// point to variable FILE_ENV_VAR_02 in section testenv:file_reference
-		const position2 = new vscode.Position(50, 20);	// point to variable FILE_ENV_VAR_03 in section testenv:multiple_values_01
+		const position1 = new vscode.Position(36, 20);	// point to variable FILE_ENV_VAR_02 in section testenv:file_reference
+		const position2 = new vscode.Position(57, 20);	// point to variable FILE_ENV_VAR_03 in section testenv:multiple_values_01
 
 		// Act
 
@@ -229,10 +229,10 @@ suite('Extension Test Suite', () => {
 
 		// A position which DOES reference a variable set by passenv or setenv.
 		// Properties line and character in Position are zero-based, VS Code UI is one-based.
-		const position1 = new vscode.Position(10, 10);	// point somewhere into section testenv:single_values_01
-		const position2 = new vscode.Position(25, 10);	// point somewhere into section testenv:file_reference
-		const position3 = new vscode.Position(5, 15);	// point into in the middle of section name testenv:single_values_01
-		const position4 = new vscode.Position(50, 15);	// point into in the middle of section name testenv:multiple_values_01
+		const position1 = new vscode.Position(16, 10);	// point somewhere into section testenv:single_values_01
+		const position2 = new vscode.Position(32, 10);	// point somewhere into section testenv:file_reference
+		const position3 = new vscode.Position(12, 15);	// point into in the middle of section name testenv:single_values_01
+		const position4 = new vscode.Position(56, 15);	// point into in the middle of section name testenv:multiple_values_01
 		const position5 = new vscode.Position(100, 100);	// point outside of document
 
 		// Act

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -31,6 +31,12 @@ function getSampleToxContent(sampleName: string): string {
 	return toxIniContent;
 }
 
+function constructExpectedHoverMessage(sectionName: string, varName: string, varValue: string) {
+	const expectedHoverMessage = `[${sectionName}] ${varName}: '${varValue}'`;
+
+	return expectedHoverMessage;
+}
+
 async function waitForTerminal() {
 	return new Promise<vscode.Terminal>(resolve => {
 		let disposable = vscode.window.onDidOpenTerminal(terminal => {
@@ -130,14 +136,14 @@ suite('Extension Test Suite', () => {
 		assert.notEqual(hoverMessage2, null);
 
 		const testPassEnvName1 = "PWD";
-		const testPassEnvValue1 = process.env[testPassEnvName1];
-		const expectedHoverMessage1 = `[testenv:single_values_01] ${testPassEnvName1}: '${testPassEnvValue1}'`;
+		const testPassEnvValue1 = process.env[testPassEnvName1] ?? "";
+		const expectedHoverMessage1 = constructExpectedHoverMessage("testenv:single_values_01", testPassEnvName1, testPassEnvValue1);
 
 		assert.equal(hoverMessage1 && hoverMessage1[0].value, expectedHoverMessage1, `For the given position the expected hover message is: '${expectedHoverMessage1}'.`);
 
 		const testPassEnvName2 = "USER";
-		const testPassEnvValue2 = process.env[testPassEnvName2];
-		const expectedHoverMessage2 = `[testenv:multiple_values_01] ${testPassEnvName2}: '${testPassEnvValue2}'`;
+		const testPassEnvValue2 = process.env[testPassEnvName2] ?? "";
+		const expectedHoverMessage2 = constructExpectedHoverMessage("testenv:multiple_values_01", testPassEnvName2, testPassEnvValue2);
 
 		assert.equal(hoverMessage2 && hoverMessage2[0].value, expectedHoverMessage2, `For the given position the expected hover message is: '${expectedHoverMessage2}'.`);
 	});
@@ -170,13 +176,13 @@ suite('Extension Test Suite', () => {
 		assert.notEqual(hoverMessage2, null);
 		assert.notEqual(hoverMessage3, null);
 
-		const expectedHoverMessage1 = "[testenv:single_values_01] LOCALUI_OUTPUT_PATH: './tests/.output_01'";
+		const expectedHoverMessage1 = constructExpectedHoverMessage("testenv:single_values_01", "LOCALUI_OUTPUT_PATH", "./tests/.output_01");
 		assert.equal(hoverMessage1 && hoverMessage1[0].value, expectedHoverMessage1, `For the given position the expected hover message is: '${expectedHoverMessage1}'.`);
 
-		const expectedHoverMessage2 = "[testenv:single_values_02] LOCALUI_OUTPUT_PATH: './tests/.output_02'";
+		const expectedHoverMessage2 = constructExpectedHoverMessage("testenv:single_values_02", "LOCALUI_OUTPUT_PATH", "./tests/.output_02");
 		assert.equal(hoverMessage2 && hoverMessage2[0].value, expectedHoverMessage2, `For the given position the expected hover message is: '${expectedHoverMessage2}'.`);
 
-		const expectedHoverMessage3 = "[testenv:multiple_values_01] REGISTRY_USER: 'value_registry_user'";
+		const expectedHoverMessage3 = constructExpectedHoverMessage("testenv:multiple_values_01", "REGISTRY_USER", "value_registry_user");
 		assert.equal(hoverMessage3 && hoverMessage3[0].value, expectedHoverMessage3, `For the given position the expected hover message is: '${expectedHoverMessage3}'.`);
 
 	});
@@ -206,10 +212,10 @@ suite('Extension Test Suite', () => {
 		assert.notEqual(hoverMessage1, null);
 		assert.notEqual(hoverMessage2, null);
 
-		const expectedHoverMessage1 = "[testenv:file_reference] FILE_ENV_VAR_02: 'value_02'";
+		const expectedHoverMessage1 = constructExpectedHoverMessage("testenv:file_reference", "FILE_ENV_VAR_02", "value_02");
 		assert.equal(hoverMessage1 && hoverMessage1[0].value, expectedHoverMessage1, `For the given position the expected hover message is: '${expectedHoverMessage1}'.`);
 
-		const expectedHoverMessage2 = "[testenv:multiple_values_01] FILE_ENV_VAR_03: 'value_03'";
+		const expectedHoverMessage2 = constructExpectedHoverMessage("testenv:multiple_values_01", "FILE_ENV_VAR_03", "value_03");
 		assert.equal(hoverMessage2 && hoverMessage2[0].value, expectedHoverMessage2, `For the given position the expected hover message is: '${expectedHoverMessage2}'.`);
 
 	});


### PR DESCRIPTION
## Addressed Changed

According to issue #19:

* Show previews via **hover messages** for environment variables in `tox.ini` files for `passenv` and `setenv` variables.
* Variables could be assigned directly in a section (environment) or in the inherited section `testenv` which can be reused by all other sections (environments).
* `passenv` variables are read from the current environment.
* `setenv` variables are assigned either directly inside the tox.ini file or indirectly referenced from an external `.env` file.

## Changes

* Added class `src/environment_variables_service.ts` which contains the logic to provide hover messages with preview data for tox environment variables.
* Added unit tests and sample files (in `src/test/examples/envvars/`) to test new features for previewing environment variables in `tox.ini` files.
* Added register command for VS Code hover integration to `src/extension.ts`.
* Added activation event in `package.json` for extended language support in `ini` files.

## How to test

* run unit tests via `npm test` from terminal or run `Extension Tests` in VS Code
* run extension, open a `tox.ini` file, and hover with the mouse over an environment variable. You will see a preview of the value of the variable.

![image](https://user-images.githubusercontent.com/5375651/165092503-fc9b86fb-4361-4df6-a776-2236d6de779c.png)


