### PR TITLE
Use tox testenv listing for generating the tree view

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"python",
 		"tox"
 	],
-	"version": "1.0.0",
+	"version": "1.0.1-dev",
 	"license": "MIT",
 	"publisher": "the-compiler",
 	"repository": {

--- a/src/run.ts
+++ b/src/run.ts
@@ -6,10 +6,14 @@ import { getTerminal } from './utils';
 
 const exec = util.promisify(child_process.exec);
 
+export const commandToxListAllEnvs = 'tox -a';
+
 export async function getToxEnvs(projDir: string) {
-	const { stdout } = await exec('tox -a', { cwd: projDir });
+	const { stdout } = await exec(commandToxListAllEnvs, { cwd: projDir });
 	return stdout.trim().split(os.EOL);
 }
+
+export const commandToxRun = 'tox -e';
 
 export function runTox(envs: string[], toxArguments: string, terminal: vscode.Terminal = getTerminal() ) {
 	const envArg = envs.join(",");
@@ -27,6 +31,6 @@ export function runTox(envs: string[], toxArguments: string, terminal: vscode.Te
 	// - Real tox environment names are very unlikely to accidentally contain
 	//   such characters - in fact, using spaces in env names seems to not work
 	//   properly at all.
-	let terminalCommand = `tox -e ${envArg} ${toxArguments}`;
+	let terminalCommand = `${commandToxRun} ${envArg} ${toxArguments}`;
 	terminal.sendText(terminalCommand);
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -15,7 +15,7 @@ export function runTox(envs: string[], toxArguments: string, terminal: vscode.Te
 	const envArg = envs.join(",");
 	terminal.show(true);  // preserve focus
 
-	// FIXME In theory, there's a command injection here, if an environment name
+	// FIXME: In theory, there's a command injection here, if an environment name
 	// contains shell metacharacters. However:
 	// - Escaping the argument in a shell-agnostic way is hard:
 	//   https://github.com/microsoft/vscode/blob/1.57.0/src/vs/workbench/contrib/debug/node/terminals.ts#L84-L211

--- a/src/testController.ts
+++ b/src/testController.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as util from 'util';
 import { runTox, getToxEnvs } from './run';
+import { getTerminal, getRootParentLabelDesc } from './utils';
 
 export function create() {
 	const controller = vscode.tests.createTestController('toxTestController', 'Tox Testing');
@@ -38,7 +39,7 @@ export function create() {
 			const start = Date.now();
 			try {
 				const cwd = vscode.workspace.getWorkspaceFolder(test.uri!)!.uri.path;
-				runTox([test.label], cwd);
+				runTox([test.label], "", getTerminal(cwd, getRootParentLabelDesc(test)));
 				run.passed(test, Date.now() - start);
 			}
 			catch (e: any) {

--- a/src/toxTaskProvider.ts
+++ b/src/toxTaskProvider.ts
@@ -106,7 +106,7 @@ async function getToxTestTasks(): Promise<vscode.Task[]> {
                 task.group = inferTaskGroup(toxTestenv.toLowerCase());
                 result.push(task);
             }
-        }    
+        }
     }
     return result;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,3 +34,18 @@ export function getTerminal(projDir : string = findProjectDir(), name : string =
 	}
 	return vscode.window.createTerminal({"cwd": projDir, "name": name});
 }
+
+/**
+ * Get the top-most parent label (+ description) for terminal name
+ * @param test The test to start from.
+ * @returns The label and description of the root test item.
+ */
+export function getRootParentLabelDesc(test: vscode.TestItem) : string {
+	let root = test;
+
+	while (root.parent !== undefined){
+		root = root.parent;
+	}
+
+	return root.label + " " + root.description; // FIXME: return as tuple?
+}


### PR DESCRIPTION
This PR is my suggestion to solve #33. It also cleans up some stuff. The last commit is subject for further discussions, works for my use-case but I will try to create a more generic test setup.